### PR TITLE
Updates Uglifier per Heroku deployment error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(:harmony => true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
- Update to previous PR: Updates `production.rb` file - Uglifier per Heroku deployment error. 
- The new line: 
```
  # Compress JavaScripts and CSS.
  config.assets.js_compressor = Uglifier.new(:harmony => true)
```
- This was the error: 
![image](https://user-images.githubusercontent.com/6686861/56229616-8f96c000-6037-11e9-8874-a4e52297c6c1.png)
